### PR TITLE
Do not crash error when input is not set

### DIFF
--- a/app/scripts/filters/withPlayerInTeam.js
+++ b/app/scripts/filters/withPlayerInTeam.js
@@ -4,7 +4,10 @@
 angular.module('babitchFrontendApp')
     .filter('withPlayerInTeam', function() {
         return function(input, withPlayer) {
-            if( !withPlayer || !input) {
+            if (!input) {
+                return false;
+            }
+            if (!withPlayer) {
                 return input;
             }
             var out = [];


### PR DESCRIPTION
When loading the player view, the filter crashed error because player's games are not loaded yet.
Just add a newer test to the filter
