### PR TITLE
Handle config.js.dist in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM stackbrew/ubuntu:saucy
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -y
-RUN apt-get install -y git nginx software-properties-common python-software-properties python g++ make
+RUN apt-get install -y git nginx software-properties-common python-software-properties python g++ make bzip2
 RUN apt-add-repository ppa:chris-lea/node.js
 RUN apt-get update -y
 RUN apt-get install -y nodejs
@@ -15,8 +15,9 @@ WORKDIR /var/www
 RUN npm install
 RUN npm install grunt
 RUN npm install -g bower grunt-cli
-
 RUN bower install --allow-root
+
+RUN cp app/scripts/config.js.dist app/scripts/config.js
 RUN grunt build
 
 ADD docker/nginx-vhost.conf /etc/nginx/sites-available/default


### PR DESCRIPTION
Long overdue, this fixes the Dockerfile vs the recent move of `config.js` to `config.js.dist`.

It also fixes a (new ?) bug in the phantomjs build.
